### PR TITLE
Fix NSRangeException crash

### DIFF
--- a/MyNotes/MasterViewController.swift
+++ b/MyNotes/MasterViewController.swift
@@ -95,7 +95,7 @@ class MasterViewController: UITableViewController {
             notes.append(note)
             index = notes.count - 1
         }
-        
+        self.tableView.reloadData()
         let indexPath = IndexPath(row: index!, section: 0)
         tableView.selectRow(at: indexPath, animated: true, scrollPosition: .bottom)
     }


### PR DESCRIPTION
During the tutorial, we noticed that there was a crash when we tried to create a new note

Reproduction Steps:
When a new note is created and the user presses back really fast, it will cause a NSRangeException.  Another way to replicate this bug is using an iPad Pro in landscape. This will have a UISplitViewController. If the user just adds a new note it will crash

Explanation:
The root cause is that the table view has not reloaded yet and the noteChanged function is trying to scroll to an index in the tableview that hasn't existed.

Fix:
The fix is to simply force a refresh when we add a note in the noteChanged method before it tries to scroll to that index.

https://stackoverflow.com/questions/26647387/uitableview-contentoffsetforscrollingtorowatindexpathatscrollposition